### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,8 @@
 name: Build and Test
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ master, develop, 'copilot/**' ]
@@ -187,6 +190,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build-linux, build-windows]
     if: github.event_name == 'release'
+    permissions:
+      contents: write
     
     steps:
     - name: Download all artifacts


### PR DESCRIPTION
Potential fix for [https://github.com/oldmagic/sm-ext-socket/security/code-scanning/4](https://github.com/oldmagic/sm-ext-socket/security/code-scanning/4)

To fix the problem, we need to add a `permissions` block at the root level in `.github/workflows/build.yml` that sets the default permissions for all jobs to least privilege. For most build and test jobs, this should be `contents: read`. For jobs that need to upload release assets––specifically, the `release` job––the contents write permission must be explicitly granted using a job-level `permissions` override.

The required changes are:
- Insert a root-level `permissions` block (immediately after `name` or before/after `on`) with `contents: read`.
- In the `release` job definition (under `jobs > release:`), add a `permissions` block with `contents: write` (this is sufficient for creating releases and uploading assets via `softprops/action-gh-release@v1`).

No imports or external definitions are needed; only YAML structural changes within `.github/workflows/build.yml`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
